### PR TITLE
VideoSourceのクリーンアップ処理を修正

### DIFF
--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/11_CacheController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/11_CacheController.cs
@@ -161,6 +161,8 @@ namespace jp.ootr.ImageDeviceController
                 if (Math.Abs(CcGarbageCollectionQueueFrameCounts[i] - Time.frameCount) < 100) continue;
                 CcGarbageCollectionQueue = CcGarbageCollectionQueue.Remove(i, out var sourceUrl);
                 CcGarbageCollectionQueueFrameCounts = CcGarbageCollectionQueueFrameCounts.Remove(i);
+                // Ensure per-source cleanup hooks run even when GC drives the removal path.
+                CcOnRelease(sourceUrl);
                 CcRemoveCache(sourceUrl);
             }
 

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/32_VideoSourceLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/32_VideoSourceLoader.cs
@@ -279,11 +279,5 @@ namespace jp.ootr.ImageDeviceController
                     return LoadError.Unknown;
             }
         }
-
-        protected override void CcOnRelease([CanBeNull] string sourceUrl)
-        {
-            base.CcOnRelease(sourceUrl);
-            CcRemoveCache(sourceUrl);
-        }
     }
 }

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/41_EIAFileLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/41_EIAFileLoader.cs
@@ -78,18 +78,30 @@ namespace jp.ootr.ImageDeviceController
             }
 
             // パース済み配列から該当ソースの要素を除外
-            var newUrls = new string[0];
-            var newBuffers = new byte[0][];
-            var newManifests = new DataDictionary[0];
-
+            var keepCount = 0;
             for (var i = 0; i < EiaParsedFileUrls.Length; i++)
             {
                 var url = EiaParsedFileUrls[i];
-                if (url.IsNullOrEmpty() || url.StartsWith(sourceUrl) == false)
+                if (url.IsNullOrEmpty() || !url.StartsWith(sourceUrl))
                 {
-                    newUrls = newUrls.Append(url);
-                    newBuffers = newBuffers.Append(EiaParsedFileBuffers[i]);
-                    newManifests = newManifests.Append(EiaParsedFileManifests[i]);
+                    keepCount++;
+                }
+            }
+
+            var newUrls = new string[keepCount];
+            var newBuffers = new byte[keepCount][];
+            var newManifests = new DataDictionary[keepCount];
+
+            var newIndex = 0;
+            for (var i = 0; i < EiaParsedFileUrls.Length; i++)
+            {
+                var url = EiaParsedFileUrls[i];
+                if (url.IsNullOrEmpty() || !url.StartsWith(sourceUrl))
+                {
+                    newUrls[newIndex] = url;
+                    newBuffers[newIndex] = EiaParsedFileBuffers[i];
+                    newManifests[newIndex] = EiaParsedFileManifests[i];
+                    newIndex++;
                 }
             }
 

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -43,30 +43,43 @@ namespace jp.ootr.ImageDeviceController
 
             if (_loadedSourceUrls.Has(sourceUrl, out var loadedIndex))
             {
-                ConsoleDebug($"already loaded. read from loaded source. {sourceUrl}",
-                    _SourceControllerPrefixes);
-                // self.OnSourceLoadSuccess(sourceUrl, _loadedSourceFileNames[loadedIndex]);
-                _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
-                _loadedSourceQueueFileNames = _loadedSourceQueueFileNames.Append(_loadedSourceFileNames[loadedIndex]);
-                _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
-                _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
-                SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
-                return true;
+                if (!CcHasCache(sourceUrl))
+                {
+                    ConsoleDebug($"cached source lost, force reload: {sourceUrl}", _SourceControllerPrefixes);
+                    _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
+                    _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);
+                }
+                else
+                {
+                    ConsoleDebug($"already loaded. read from loaded source. {sourceUrl}",
+                        _SourceControllerPrefixes);
+                    // self.OnSourceLoadSuccess(sourceUrl, _loadedSourceFileNames[loadedIndex]);
+                    _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
+                    _loadedSourceQueueFileNames = _loadedSourceQueueFileNames.Append(_loadedSourceFileNames[loadedIndex]);
+                    _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
+                    _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
+                    SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
+                    return true;
+                }
             }
 
             if (CcHasCache(sourceUrl))
             {
                 var files = CcGetCache(sourceUrl);
                 var fileNames = files.GetFileUrls();
-                ConsoleDebug($"already loaded. read from cache. {fileNames.Length} files, {sourceUrl}",
-                    _SourceControllerPrefixes);
-                // self.OnSourceLoadSuccess(sourceUrl, fileNames);
-                _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
-                _loadedSourceQueueFileNames = _loadedSourceQueueFileNames.Append(fileNames);
-                _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
-                _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
-                SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
-                return true;
+                if (fileNames.Length > 0)
+                {
+                    ConsoleDebug($"already loaded. read from cache. {fileNames.Length} files, {sourceUrl}",
+                        _SourceControllerPrefixes);
+                    // self.OnSourceLoadSuccess(sourceUrl, fileNames);
+                    _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
+                    _loadedSourceQueueFileNames = _loadedSourceQueueFileNames.Append(fileNames);
+                    _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
+                    _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
+                    SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
+                    return true;
+                }
+                ConsoleDebug($"cache entry missing files, fallback to reload: {sourceUrl}", _SourceControllerPrefixes);
             }
 
             ConsoleDebug($"loading {sourceUrl}.", _SourceControllerPrefixes);
@@ -151,6 +164,8 @@ namespace jp.ootr.ImageDeviceController
         protected override void CcOnRelease(string sourceUrl)
         {
             base.CcOnRelease(sourceUrl);
+            // EIA 側のパース済みデータやキューをソース単位でクリア
+            EIAForceClearSource(sourceUrl);
             if (!_loadedSourceUrls.Has(sourceUrl, out var loadedIndex)) return;
             _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
             _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -164,8 +164,6 @@ namespace jp.ootr.ImageDeviceController
         protected override void CcOnRelease(string sourceUrl)
         {
             base.CcOnRelease(sourceUrl);
-            // EIA 側のパース済みデータやキューをソース単位でクリア
-            EIAForceClearSource(sourceUrl);
             if (!_loadedSourceUrls.Has(sourceUrl, out var loadedIndex)) return;
             _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
             _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -46,6 +46,7 @@ namespace jp.ootr.ImageDeviceController
                 if (!CcHasCache(sourceUrl))
                 {
                     ConsoleDebug($"cached source lost, force reload: {sourceUrl}", _SourceControllerPrefixes);
+                    EIAForceClearSource(sourceUrl);
                     _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
                     _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);
                 }
@@ -80,6 +81,7 @@ namespace jp.ootr.ImageDeviceController
                     return true;
                 }
                 ConsoleDebug($"cache entry missing files, fallback to reload: {sourceUrl}", _SourceControllerPrefixes);
+                EIAForceClearSource(sourceUrl);
             }
 
             ConsoleDebug($"loading {sourceUrl}.", _SourceControllerPrefixes);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to forcibly clear a specific source’s queued and parsed data and interrupt its loading; clearing can now be customized by subclasses.

* **Bug Fixes**
  * Ensured per-source cleanup hooks run during garbage collection so resources are fully released.
  * Improved cache validation so sources reload when cached files are missing.
  * Adjusted release behavior to avoid unintended cache removals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->