### PR TITLE
MaximumDimensionExceededを別エラーコードに分離

### DIFF
--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
@@ -314,7 +314,7 @@ namespace jp.ootr.ImageDeviceController
                     break;
                 case LoadError.InvalidImage:
                     title = "非対応形式の画像です";
-                    content = "リンク先が画像であっているか、画像が2048x2048以下に収まっているか確認してみてください";
+                    content = "リンク先が画像であっているか確認してみてください";
                     break;
                 case LoadError.MaximumDimensionExceeded:
                     title = "画像の最大寸法を超えています";
@@ -438,7 +438,7 @@ namespace jp.ootr.ImageDeviceController
                     break;
                 case LoadError.InvalidImage:
                     title = "Invalid image";
-                    content = "Check if the link is an image or if the image is within 2048x2048";
+                    content = "Check if the link is an image";
                     break;
                 case LoadError.MaximumDimensionExceeded:
                     title = "Image exceeds maximum dimensions";

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
@@ -442,7 +442,7 @@ namespace jp.ootr.ImageDeviceController
                     break;
                 case LoadError.MaximumDimensionExceeded:
                     title = "Image exceeds maximum dimensions";
-                    content = "Maximum dimensions exceeded (2048x2048)";
+                    content = "Ensure the image's dimensions do not exceed 2048x2048 (resize the image or choose a smaller image).";
                     break;
                 case LoadError.TooManyRequests:
                     title = "Too many requests";

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
@@ -33,6 +33,7 @@ namespace jp.ootr.ImageDeviceController
         InsecureURL,
         DuplicateURL,
         URLNotSynced,
+        MaximumDimensionExceeded,
 
         //UNITY ERROR
         HostNotFound,
@@ -157,6 +158,8 @@ namespace jp.ootr.ImageDeviceController
                     return "ootr:MissingUdonZip";
                 case LoadError.InvalidZipFile:
                     return "ootr:InvalidZipFile";
+                case LoadError.MaximumDimensionExceeded:
+                    return "ootr:MaximumDimensionExceeded";
 
                 case LoadError.PlayerError:
                     return "VRC:PlayerError";
@@ -313,6 +316,10 @@ namespace jp.ootr.ImageDeviceController
                     title = "非対応形式の画像です";
                     content = "リンク先が画像であっているか、画像が2048x2048以下に収まっているか確認してみてください";
                     break;
+                case LoadError.MaximumDimensionExceeded:
+                    title = "画像の最大寸法を超えています";
+                    content = "画像が2048x2048以下に収まっているか確認してみてください";
+                    break;
                 case LoadError.TooManyRequests:
                     title = "リクエストが多すぎます";
                     content = "時間をおいて再度試してみてください";
@@ -432,6 +439,10 @@ namespace jp.ootr.ImageDeviceController
                 case LoadError.InvalidImage:
                     title = "Invalid image";
                     content = "Check if the link is an image or if the image is within 2048x2048";
+                    break;
+                case LoadError.MaximumDimensionExceeded:
+                    title = "Image exceeds maximum dimensions";
+                    content = "Maximum dimensions exceeded (2048x2048)";
                     break;
                 case LoadError.TooManyRequests:
                     title = "Too many requests";

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
@@ -52,6 +52,9 @@ namespace jp.ootr.ImageDeviceController
         {
             if (error == LoadError.DownloadError && message == "Redirect limit exceeded")
                 return LoadError.RedirectNotAllowed;
+            
+            if (error == LoadError.InvalidImage && message == "Failed to load file: MaximumDimensionExceeded")
+                return LoadError.MaximumDimensionExceeded;
 
             if (error == LoadError.DownloadError && message != null)
             {

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
@@ -52,7 +52,7 @@ namespace jp.ootr.ImageDeviceController
         {
             if (error == LoadError.DownloadError && message == "Redirect limit exceeded")
                 return LoadError.RedirectNotAllowed;
-            
+
             if (error == LoadError.InvalidImage && message == "Failed to load file: MaximumDimensionExceeded")
                 return LoadError.MaximumDimensionExceeded;
 


### PR DESCRIPTION
VRCImageDownloader による 2048x2048 上限エラーを個別エラーとして切り出し、利用できるように改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a distinct error for images exceeding the 2048x2048 limit and improved handling when that occurs.
  * Updated user-facing messages in Japanese and English with clear guidance about the maximum dimensions.
  * Simplified the generic invalid-image message to focus on image validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->