### PR TITLE
ZipSourceLoader: UdonZip APIのnull戻り値を適切にハンドリング

### DIFF
--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
@@ -318,7 +318,7 @@ namespace jp.ootr.ImageDeviceController
                     break;
                 case LoadError.MaximumDimensionExceeded:
                     title = "画像の最大寸法を超えています";
-                    content = "画像が2048x2048以下に収まっているか確認してみてください";
+                    content = "2048x2048 以下に画像を縮小するか、以下のプロキシ URL を使用してください。\nなお、プロキシサービスを使用する場合は利用規約とプライバシーポリシーに同意する必要があります";
                     break;
                 case LoadError.TooManyRequests:
                     title = "リクエストが多すぎます";
@@ -442,7 +442,7 @@ namespace jp.ootr.ImageDeviceController
                     break;
                 case LoadError.MaximumDimensionExceeded:
                     title = "Image exceeds maximum dimensions";
-                    content = "Ensure the image's dimensions do not exceed 2048x2048 (resize the image or choose a smaller image).";
+                    content = "Please resize the image to 2048x2048 or smaller, or use the proxy below";
                     break;
                 case LoadError.TooManyRequests:
                     title = "Too many requests";

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
@@ -442,7 +442,7 @@ namespace jp.ootr.ImageDeviceController
                     break;
                 case LoadError.MaximumDimensionExceeded:
                     title = "Image exceeds maximum dimensions";
-                    content = "Please resize the image to 2048x2048 or smaller, or use the proxy below";
+                    content = "Please resize the image to 2048x2048 or smaller, or use the proxy below.\nNote that using the proxy service requires agreeing to its Terms of Service and Privacy Policy";
                     break;
                 case LoadError.TooManyRequests:
                     title = "Too many requests";

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
@@ -96,8 +96,26 @@ namespace jp.ootr.ImageDeviceController
         {
             ConsoleDebug("extracting data.", _zipLoaderPrefixes);
             _zlObject = zlUdonZip.Extract(_zlDecodedData);
+            if (_zlObject == null)
+            {
+                ZlOnLoadError(_zlSourceUrl, LoadError.InvalidZipFile);
+                ConsoleError($"failed to extract zip. {_zlSourceUrl}", _zipLoaderPrefixes);
+                return;
+            }
             var file = zlUdonZip.GetFile(_zlObject, "metadata.json");
+            if (file == null)
+            {
+                ZlOnLoadError(_zlSourceUrl, LoadError.InvalidZipFile);
+                ConsoleError($"metadata.json not found in zip. {_zlSourceUrl}", _zipLoaderPrefixes);
+                return;
+            }
             var metadata = zlUdonZip.GetFileData(file);
+            if (metadata == null)
+            {
+                ZlOnLoadError(_zlSourceUrl, LoadError.InvalidZipFile);
+                ConsoleError($"failed to read metadata.json from zip. {_zlSourceUrl}", _zipLoaderPrefixes);
+                return;
+            }
             VRCJson.TryDeserializeFromJson(Encoding.UTF8.GetString(metadata), out var metadataToken);
             if (TextZipUtils.ValidateManifest(metadataToken, out _zlMetadata, out var manifestVersion,
                     out var requiredFeatures, out var void1) != ParseResult.Success || requiredFeatures == null ||
@@ -146,6 +164,11 @@ namespace jp.ootr.ImageDeviceController
             }
 
             var imageBytes = GenerateImageBytes(extensions, width, format, path);
+            if (imageBytes == null)
+            {
+                // GenerateImageBytes already called ZlOnLoadError / ConsoleError
+                return;
+            }
             var texture = new Texture2D(width, height, format, false);
             texture.LoadRawTextureData(imageBytes);
             texture.Apply();
@@ -185,7 +208,17 @@ namespace jp.ootr.ImageDeviceController
                     if (!rects.TryGetValue(i, TokenType.DataDictionary, out var rect)) continue;
                     if (rect.DataDictionary.TryGetRectMetadata(out var baseX, out var baseY, out var w, out var h, out var rectPath) != ParseResult.Success) continue;
                     var rectFile = zlUdonZip.GetFile(_zlObject, rectPath);
+                    if (rectFile == null)
+                    {
+                        ConsoleError($"missing rect file: {rectPath}", _zipLoaderPrefixes);
+                        continue;
+                    }
                     var rectBytes = zlUdonZip.GetFileData(rectFile);
+                    if (rectBytes == null)
+                    {
+                        ConsoleError($"failed to decompress rect file: {rectPath}", _zipLoaderPrefixes);
+                        continue;
+                    }
                     for (var y = 0; y < h; y++)
                     {
                         Array.Copy(rectBytes, y * w * bytePerPixel, baseImage, (baseY + y) * width * bytePerPixel + baseX * bytePerPixel, w * bytePerPixel);
@@ -195,7 +228,20 @@ namespace jp.ootr.ImageDeviceController
                 return baseImage;
             }
             var imageFile = zlUdonZip.GetFile(_zlObject, path);
-            return zlUdonZip.GetFileData(imageFile);
+            if (imageFile == null)
+            {
+                ZlOnLoadError(_zlSourceUrl, LoadError.InvalidMetadata);
+                ConsoleError($"image file not found in zip: {path}", _zipLoaderPrefixes);
+                return null;
+            }
+            var imageBytes = zlUdonZip.GetFileData(imageFile);
+            if (imageBytes == null)
+            {
+                ZlOnLoadError(_zlSourceUrl, LoadError.InvalidMetadata);
+                ConsoleError($"failed to decompress image file: {path}", _zipLoaderPrefixes);
+                return null;
+            }
+            return imageBytes;
         }
 
         protected virtual void ZlOnLoadProgress([CanBeNull] string sourceUrl, float progress)

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
@@ -210,14 +210,16 @@ namespace jp.ootr.ImageDeviceController
                     var rectFile = zlUdonZip.GetFile(_zlObject, rectPath);
                     if (rectFile == null)
                     {
+                        ZlOnLoadError(_zlSourceUrl, LoadError.InvalidMetadata);
                         ConsoleError($"missing rect file: {rectPath}", _zipLoaderPrefixes);
-                        continue;
+                        return null;
                     }
                     var rectBytes = zlUdonZip.GetFileData(rectFile);
                     if (rectBytes == null)
                     {
+                        ZlOnLoadError(_zlSourceUrl, LoadError.InvalidMetadata);
                         ConsoleError($"failed to decompress rect file: {rectPath}", _zipLoaderPrefixes);
-                        continue;
+                        return null;
                     }
                     for (var y = 0; y < h; y++)
                     {


### PR DESCRIPTION
UdonZip.ExtractおよびGetFileDataがnullを返す可能性があるようになったため、
各呼び出し箇所にnullチェックを追加してLoadError.InvalidZipFileとして伝播する。

- ZlExtractData: Extract/GetFile/GetFileDataのnull戻り値を検知してOnLoadError呼び出し
- ZlExtractItem: GenerateImageBytesがnullを返した場合に早期returnを追加
- GenerateImageBytes: GetFile/GetFileDataのnull戻り値を検知してエラーログと早期return
  (cropped/通常両パス対応)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for oversized images, now providing clearer guidance on resizing to the 2048x2048 limit and introducing proxy service as an alternative solution.
  * Enhanced validation and error handling during image processing and archive file extraction, including better detection and reporting of missing or corrupted metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->