### PR TITLE
SourceController: ロード済み判定で CcHasCache ガードを撤廃

### DIFF
--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -41,47 +41,18 @@ namespace jp.ootr.ImageDeviceController
                 return true;
             }
 
+            // eia のマニフェスト取得直後は Texture2D 未投入のため CcHasCache でガードしない (GC は _loadedSourceUrls 側も整理するので不要)
             if (_loadedSourceUrls.Has(sourceUrl, out var loadedIndex))
             {
-                if (!CcHasCache(sourceUrl))
-                {
-                    ConsoleDebug($"cached source lost, force reload: {sourceUrl}", _SourceControllerPrefixes);
-                    _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
-                    _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);
-                }
-                else
-                {
-                    ConsoleDebug($"already loaded. read from loaded source. {sourceUrl}",
-                        _SourceControllerPrefixes);
-                    // self.OnSourceLoadSuccess(sourceUrl, _loadedSourceFileNames[loadedIndex]);
-                    _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
-                    _loadedSourceQueueFileNames =
-                        _loadedSourceQueueFileNames.Append(_loadedSourceFileNames[loadedIndex]);
-                    _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
-                    _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
-                    SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
-                    return true;
-                }
-            }
-
-            if (CcHasCache(sourceUrl))
-            {
-                var files = CcGetCache(sourceUrl);
-                var fileNames = files.GetFileUrls();
-                if (fileNames.Length > 0)
-                {
-                    ConsoleDebug($"already loaded. read from cache. {fileNames.Length} files, {sourceUrl}",
-                        _SourceControllerPrefixes);
-                    // self.OnSourceLoadSuccess(sourceUrl, fileNames);
-                    _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
-                    _loadedSourceQueueFileNames = _loadedSourceQueueFileNames.Append(fileNames);
-                    _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
-                    _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
-                    SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
-                    return true;
-                }
-
-                ConsoleDebug($"cache entry missing files, fallback to reload: {sourceUrl}", _SourceControllerPrefixes);
+                ConsoleDebug($"already loaded. read from loaded source. {sourceUrl}",
+                    _SourceControllerPrefixes);
+                _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
+                _loadedSourceQueueFileNames =
+                    _loadedSourceQueueFileNames.Append(_loadedSourceFileNames[loadedIndex]);
+                _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
+                _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
+                SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
+                return true;
             }
 
             ConsoleDebug($"loading {sourceUrl}.", _SourceControllerPrefixes);

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -43,7 +43,8 @@ namespace jp.ootr.ImageDeviceController
 
             // _loadedSourceUrls は「ローダから OnSourceLoadSuccess 済み」のシグナルで、キャッシュ上のテクスチャ状態とは独立。
             // eia のような非同期ローダは Texture2D 投入前にこのリストへエントリを追加するため、キャッシュ有無で判定してはいけない。
-            // キャッシュが GC / 退避されていても、CacheController.TryRegenerateTexture が _cacheBinary から復元する。
+            // なおソース単位の GC (CcRemoveCache) では CcOnRelease がこのリストも同時に整理するので、ここに残っていれば
+            // _cacheBinary も生きており、個別 Texture2D が破棄されていても CacheController.TryRegenerateTexture で復元可能。
             if (_loadedSourceUrls.Has(sourceUrl, out var loadedIndex))
             {
                 var loadedFileNames = _loadedSourceFileNames[loadedIndex];

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -44,15 +44,25 @@ namespace jp.ootr.ImageDeviceController
             // eia のマニフェスト取得直後は Texture2D 未投入のため CcHasCache でガードしない (GC は _loadedSourceUrls 側も整理するので不要)
             if (_loadedSourceUrls.Has(sourceUrl, out var loadedIndex))
             {
-                ConsoleDebug($"already loaded. read from loaded source. {sourceUrl}",
+                var loadedFileNames = _loadedSourceFileNames[loadedIndex];
+                if (loadedFileNames != null && loadedFileNames.Length > 0)
+                {
+                    ConsoleDebug($"already loaded. read from loaded source. {sourceUrl}",
+                        _SourceControllerPrefixes);
+                    _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
+                    _loadedSourceQueueFileNames = _loadedSourceQueueFileNames.Append(loadedFileNames);
+                    _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
+                    _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
+                    SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
+                    return true;
+                }
+
+                // 壊れたエントリ (null/空) は SendLoadedSourceNotification で drop されるため、
+                // ここで除去して通常ロード経路にフォールバックする
+                ConsoleWarn($"loaded source entry is empty, fallback to reload: {sourceUrl}",
                     _SourceControllerPrefixes);
-                _loadedSourceQueueUrls = _loadedSourceQueueUrls.Append(sourceUrl);
-                _loadedSourceQueueFileNames =
-                    _loadedSourceQueueFileNames.Append(_loadedSourceFileNames[loadedIndex]);
-                _loadedSourceQueueDevices = _loadedSourceQueueDevices.Append(self);
-                _loadedSourceQueueFrameCounts = _loadedSourceQueueFrameCounts.Append(Time.frameCount);
-                SendCustomEventDelayedFrames(nameof(SendLoadedSourceNotification), 1);
-                return true;
+                _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
+                _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);
             }
 
             ConsoleDebug($"loading {sourceUrl}.", _SourceControllerPrefixes);

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/51_SourceController.cs
@@ -41,7 +41,9 @@ namespace jp.ootr.ImageDeviceController
                 return true;
             }
 
-            // eia のマニフェスト取得直後は Texture2D 未投入のため CcHasCache でガードしない (GC は _loadedSourceUrls 側も整理するので不要)
+            // _loadedSourceUrls は「ローダから OnSourceLoadSuccess 済み」のシグナルで、キャッシュ上のテクスチャ状態とは独立。
+            // eia のような非同期ローダは Texture2D 投入前にこのリストへエントリを追加するため、キャッシュ有無で判定してはいけない。
+            // キャッシュが GC / 退避されていても、CacheController.TryRegenerateTexture が _cacheBinary から復元する。
             if (_loadedSourceUrls.Has(sourceUrl, out var loadedIndex))
             {
                 var loadedFileNames = _loadedSourceFileNames[loadedIndex];
@@ -57,9 +59,11 @@ namespace jp.ootr.ImageDeviceController
                     return true;
                 }
 
-                // 壊れたエントリ (null/空) は SendLoadedSourceNotification で drop されるため、
-                // ここで除去して通常ロード経路にフォールバックする
-                ConsoleWarn($"loaded source entry is empty, fallback to reload: {sourceUrl}",
+                // OnSourceLoadSuccess は空配列を弾くので通常はここに到達しない。
+                // もし到達したら _loadedSourceUrls と _loadedSourceFileNames が index ずれしているなどの状態破壊を意味するバグ。
+                ConsoleError(
+                    $"loaded source entry is null/empty, fallback to reload: {sourceUrl} " +
+                    $"(loadedIndex={loadedIndex}, urls={_loadedSourceUrls.Length}, fileNames={_loadedSourceFileNames.Length})",
                     _SourceControllerPrefixes);
                 _loadedSourceUrls = _loadedSourceUrls.Remove(loadedIndex);
                 _loadedSourceFileNames = _loadedSourceFileNames.Remove(loadedIndex);


### PR DESCRIPTION
eia のようにマニフェスト取得と Texture2D キャッシュ投入が非同期分離した
ソースで、1 つ目の Device への OnSourceLoadSuccess 発火と同フレームで 2 つ目以降の Device が LoadSource を呼ぶと、CcHasCache が false を返し "cached source lost, force reload" 経路に入って不要な再ダウンロードが 走っていた。ImageScreen 側のロード表示が 20 秒以上消えない不具合の原因。

_loadedSourceUrls は CcOnRelease/CcGarbageCollect 経由で GC 時に必ず 整理されるため、存在判定だけで _loadedSourceFileNames を信頼してよい。
2 人目以降も deferred notification 経路で即 OnSourceLoadSuccess が返る。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the source loading mechanism by removing redundant cache-validation logic and consolidating internal notification workflows. The streamlined approach ensures more consistent handling of previously loaded sources, reduces code complexity, and enhances system maintainability while fully preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->