### PR TITLE
悪意ある入力によるクラッシュ / メモリ枯渇の防御を追加

### DIFF
--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/00_Enums.cs
@@ -58,6 +58,9 @@ namespace jp.ootr.ImageDeviceController
         //EIALoader
         MissingUdonLZ4,
         InvalidEIAFile,
+        MalformedManifest,
+        CircularReference,
+        SizeLimitExceeded,
 
         //StringLoader
         UnknownFileFormat,
@@ -186,6 +189,12 @@ namespace jp.ootr.ImageDeviceController
                     return "ootr:EIA:MissingUdonLZ4";
                 case LoadError.InvalidEIAFile:
                     return "ootr:EIA:InvalidEIAFile";
+                case LoadError.MalformedManifest:
+                    return "ootr:MalformedManifest";
+                case LoadError.CircularReference:
+                    return "ootr:CircularReference";
+                case LoadError.SizeLimitExceeded:
+                    return "ootr:SizeLimitExceeded";
 
                 case LoadError.UnknownFileFormat:
                     return "ootr:String:UnknownFileFormat";
@@ -394,6 +403,18 @@ namespace jp.ootr.ImageDeviceController
                     title = "無効なEIAファイル形式です";
                     content = "再度試すか、アップロードし直してみてください";
                     break;
+                case LoadError.MalformedManifest:
+                    title = "マニフェストが不正です";
+                    content = "ファイルが破損している可能性があります。アップロードし直してみてください";
+                    break;
+                case LoadError.CircularReference:
+                    title = "画像の参照が循環しています";
+                    content = "ファイルが破損している可能性があります。アップロードし直してみてください";
+                    break;
+                case LoadError.SizeLimitExceeded:
+                    title = "許容サイズを超過しています";
+                    content = "4096x4096 以下に画像を縮小してから再度アップロードしてください";
+                    break;
                 case LoadError.UnknownFileFormat:
                     title = "無効なファイル形式です";
                     content = "ファイルがサポートされているフォーマットか確認してください";
@@ -518,6 +539,18 @@ namespace jp.ootr.ImageDeviceController
                 case LoadError.InvalidEIAFile:
                     title = "Invalid EIA file format";
                     content = "Please try again or re-upload";
+                    break;
+                case LoadError.MalformedManifest:
+                    title = "Manifest is malformed";
+                    content = "The file may be corrupted. Please try re-uploading";
+                    break;
+                case LoadError.CircularReference:
+                    title = "Circular reference in image chain";
+                    content = "The file may be corrupted. Please try re-uploading";
+                    break;
+                case LoadError.SizeLimitExceeded:
+                    title = "Exceeded maximum allowed size";
+                    content = "Please resize the image to 4096x4096 or smaller and re-upload";
                     break;
                 case LoadError.UnknownFileFormat:
                     title = "Invalid file format";

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
@@ -29,6 +29,36 @@ namespace jp.ootr.ImageDeviceController
 
         public readonly int SupportedManifestVersion = 1;
 
+        // 悪意あるマニフェストからの自己防衛上限値
+        // 実運用上、4096x4096 RGBA (64MiB) を超える画像は画像看板の用途として想定外
+        public const int MAX_IMAGE_DIMENSION = 4096;
+        public const int MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024; // 64 MiB
+        public const int MAX_BASE_CHAIN_HOPS = 32;
+
+        // w/h/bpp が MAX_* 制約を満たすかを判定する
+        // 不正なら err に LoadError を設定して false を返す (bpp>0 前提)
+        protected static bool TryValidateImageDimensions(int w, int h, int bpp, out LoadError err)
+        {
+            if (w <= 0 || h <= 0 || bpp <= 0)
+            {
+                err = LoadError.MalformedManifest;
+                return false;
+            }
+            if (w > MAX_IMAGE_DIMENSION || h > MAX_IMAGE_DIMENSION)
+            {
+                err = LoadError.MaximumDimensionExceeded;
+                return false;
+            }
+            // (long) で明示してオーバーフロー回避
+            if ((long)w * h * bpp > MAX_UNCOMPRESSED_BYTES)
+            {
+                err = LoadError.SizeLimitExceeded;
+                return false;
+            }
+            err = LoadError.Unknown;
+            return true;
+        }
+
         protected virtual LoadError ParseStringDownloadError([CanBeNull] string message, int code)
         {
             if (message == "Client has too many requests (limit is 1000)." && code == 429)

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/01_CommonClass.cs
@@ -33,7 +33,7 @@ namespace jp.ootr.ImageDeviceController
         // 実運用上、4096x4096 RGBA (64MiB) を超える画像は画像看板の用途として想定外
         public const int MAX_IMAGE_DIMENSION = 4096;
         public const int MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024; // 64 MiB
-        public const int MAX_BASE_CHAIN_HOPS = 32;
+        public const int MAX_BASE_CHAIN_HOPS = 16;
 
         // w/h/bpp が MAX_* 制約を満たすかを判定する
         // 不正なら err に LoadError を設定して false を返す (bpp>0 前提)

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
@@ -163,6 +163,17 @@ namespace jp.ootr.ImageDeviceController
                 return;
             }
 
+            // 悪意ある ZIP による OOM / Texture2D クラッシュ回避: 寸法上限を検証
+            var zipBytePerPixel = format.GetBytePerPixel();
+            if (!TryValidateImageDimensions(width, height, zipBytePerPixel, out var zipDimErr))
+            {
+                ConsoleError(
+                    $"TextZip dimensions exceed limits: {path} ({width}x{height}) - {zipDimErr}",
+                    _zipLoaderPrefixes);
+                ZlOnLoadError(_zlSourceUrl, zipDimErr);
+                return;
+            }
+
             var imageBytes = GenerateImageBytes(extensions, width, format, path);
             if (imageBytes == null)
             {
@@ -207,6 +218,19 @@ namespace jp.ootr.ImageDeviceController
                 {
                     if (!rects.TryGetValue(i, TokenType.DataDictionary, out var rect)) continue;
                     if (rect.DataDictionary.TryGetRectMetadata(out var baseX, out var baseY, out var w, out var h, out var rectPath) != ParseResult.Success) continue;
+
+                    // rect 境界検証: 悪意ある metadata による ArgumentOutOfRangeException や base 画像への OOB 書き込みを防ぐ
+                    if (
+                        baseX < 0 || baseY < 0 || w <= 0 || h <= 0
+                        || (long)baseX + w > width
+                        || (long)baseY + h > height
+                    )
+                    {
+                        ZlOnLoadError(_zlSourceUrl, LoadError.MalformedManifest);
+                        ConsoleError($"rect out of range: {rectPath} baseX={baseX} baseY={baseY} w={w} h={h}", _zipLoaderPrefixes);
+                        return null;
+                    }
+
                     var rectFile = zlUdonZip.GetFile(_zlObject, rectPath);
                     if (rectFile == null)
                     {
@@ -221,6 +245,22 @@ namespace jp.ootr.ImageDeviceController
                         ConsoleError($"failed to decompress rect file: {rectPath}", _zipLoaderPrefixes);
                         return null;
                     }
+
+                    // 最終行の src/dst オフセットが配列境界内に収まるかを long で確認
+                    var rectLineByteLength = (long)w * bytePerPixel;
+                    var imageLineByteLength = (long)width * bytePerPixel;
+                    var lastSrcOffset = (long)(h - 1) * rectLineByteLength;
+                    var lastDstOffset = (long)(baseY + h - 1) * imageLineByteLength + (long)baseX * bytePerPixel;
+                    if (
+                        lastSrcOffset + rectLineByteLength > rectBytes.Length
+                        || lastDstOffset + rectLineByteLength > baseImage.Length
+                    )
+                    {
+                        ZlOnLoadError(_zlSourceUrl, LoadError.MalformedManifest);
+                        ConsoleError($"rect copy would overrun buffer: {rectPath}", _zipLoaderPrefixes);
+                        return null;
+                    }
+
                     for (var y = 0; y < h; y++)
                     {
                         Array.Copy(rectBytes, y * w * bytePerPixel, baseImage, (baseY + y) * width * bytePerPixel + baseX * bytePerPixel, w * bytePerPixel);

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/31_1_ZipSourceLoader.cs
@@ -174,7 +174,7 @@ namespace jp.ootr.ImageDeviceController
                 return;
             }
 
-            var imageBytes = GenerateImageBytes(extensions, width, format, path);
+            var imageBytes = GenerateImageBytes(extensions, width, height, format, path);
             if (imageBytes == null)
             {
                 // GenerateImageBytes already called ZlOnLoadError / ConsoleError
@@ -198,7 +198,7 @@ namespace jp.ootr.ImageDeviceController
         }
 
         [CanBeNull]
-        private byte[] GenerateImageBytes(DataDictionary extensions, int width, TextureFormat format, string path)
+        private byte[] GenerateImageBytes(DataDictionary extensions, int width, int height, TextureFormat format, string path)
         {
 
             if (extensions.TryGetCroppedMetadata(out var basePath, out var rects) == ParseResult.Success)
@@ -213,6 +213,20 @@ namespace jp.ootr.ImageDeviceController
                 }
 
                 var bytePerPixel = format.GetBytePerPixel();
+
+                // キャッシュ汚染対策: baseImage はキャッシュ共有バッファなので、
+                // 新規バッファに複製してから加工する (EIAFileLoader の EIAGenerateImageBytesAsyncInitCopy と同等の扱い)
+                var expectedBaseLength = (long)width * height * bytePerPixel;
+                if (baseImage.Length != expectedBaseLength)
+                {
+                    ZlOnLoadError(_zlSourceUrl, LoadError.MalformedManifest);
+                    ConsoleError(
+                        $"base image size mismatch: expected={expectedBaseLength} actual={baseImage.Length} ({basePath})",
+                        _zipLoaderPrefixes);
+                    return null;
+                }
+                var workBuffer = new byte[baseImage.Length];
+                Array.Copy(baseImage, workBuffer, baseImage.Length);
 
                 for (int i = 0; i < rects.Count; i++)
                 {
@@ -253,7 +267,7 @@ namespace jp.ootr.ImageDeviceController
                     var lastDstOffset = (long)(baseY + h - 1) * imageLineByteLength + (long)baseX * bytePerPixel;
                     if (
                         lastSrcOffset + rectLineByteLength > rectBytes.Length
-                        || lastDstOffset + rectLineByteLength > baseImage.Length
+                        || lastDstOffset + rectLineByteLength > workBuffer.Length
                     )
                     {
                         ZlOnLoadError(_zlSourceUrl, LoadError.MalformedManifest);
@@ -263,11 +277,11 @@ namespace jp.ootr.ImageDeviceController
 
                     for (var y = 0; y < h; y++)
                     {
-                        Array.Copy(rectBytes, y * w * bytePerPixel, baseImage, (baseY + y) * width * bytePerPixel + baseX * bytePerPixel, w * bytePerPixel);
+                        Array.Copy(rectBytes, y * w * bytePerPixel, workBuffer, (baseY + y) * width * bytePerPixel + baseX * bytePerPixel, w * bytePerPixel);
                     }
                 }
 
-                return baseImage;
+                return workBuffer;
             }
             var imageFile = zlUdonZip.GetFile(_zlObject, path);
             if (imageFile == null)

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/31_2_EIASourceLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/31_2_EIASourceLoader.cs
@@ -126,13 +126,24 @@ namespace jp.ootr.ImageDeviceController
 
             var fileUrl = EIABuildFileName(_eiaSourceUrl, fileName.String);
 
-            if (fileType.String == "m")
+            var w = (int)fileWidth.Double;
+            var h = (int)fileHeight.Double;
+            // 最悪ケース (RGBA32 = 4 bytes/pixel) で上限チェック
+            // master と cropped で実 bpp は format により変わるが、ここでは 4 を使って保守的に判定する
+            if (!TryValidateImageDimensions(w, h, 4, out var dimErr))
             {
-                EIAParseMasterImage(fileManifest.DataDictionary, fileUrl, fileName.String, (int)fileWidth.Double, (int)fileHeight.Double);
+                ConsoleError($"EIA manifest exceeds size limits: {fileName.String} ({w}x{h}) - {dimErr}", _eiaSourceLoaderPrefixes);
+                EIAOnLoadError(_eiaSourceUrl, dimErr);
                 return;
             }
 
-            EIAParseCroppedImage(fileManifest.DataDictionary, fileUrl, fileName.String, (int)fileWidth.Double, (int)fileHeight.Double);
+            if (fileType.String == "m")
+            {
+                EIAParseMasterImage(fileManifest.DataDictionary, fileUrl, fileName.String, w, h);
+                return;
+            }
+
+            EIAParseCroppedImage(fileManifest.DataDictionary, fileUrl, fileName.String, w, h);
         }
 
         private void EIAParseMasterImage(DataDictionary fileManifest, string fileUrl, string fileName, int fileWidth, int fileHeight)

--- a/Runtime/jp.ootr.ImageDeviceController/Scripts/41_EIAFileLoader.cs
+++ b/Runtime/jp.ootr.ImageDeviceController/Scripts/41_EIAFileLoader.cs
@@ -75,9 +75,17 @@ namespace jp.ootr.ImageDeviceController
                 EiaParsedFileManifests[index].TryGetValue("t", TokenType.String, out var type)
                 && type.String == "c"
                 && EiaParsedFileManifests[index].TryGetValue("b", TokenType.String, out var baseUrl)
-                && EiaParsedFileUrls.Has(baseUrl.String, out index)
             )
             {
+                // 循環参照・過深チェイン検知: 悪意あるマニフェストで無限ループ/メモリ枯渇を回避
+                if (toLoadUrls.Has(baseUrl.String) || toLoadUrls.Length >= MAX_BASE_CHAIN_HOPS)
+                {
+                    ConsoleError($"Circular or too-deep base URL chain detected: {baseUrl.String}", _eiaFileLoaderPrefixes);
+                    OnFileLoadError(fileUrl, LoadError.CircularReference);
+                    SendCustomEvent(nameof(EIALoadFIleNext));
+                    return;
+                }
+                if (!EiaParsedFileUrls.Has(baseUrl.String, out index)) break;
                 toLoadUrls = toLoadUrls.Append(baseUrl.String);
                 ConsoleDebug($"Loading base URL: {baseUrl.String} {type.String}", _eiaFileLoaderPrefixes);
             }
@@ -140,9 +148,15 @@ namespace jp.ootr.ImageDeviceController
                 EiaParsedFileManifests[index].TryGetValue("t", TokenType.String, out var type)
                 && type.String == "c"
                 && EiaParsedFileManifests[index].TryGetValue("b", TokenType.String, out var baseUrl)
-                && EiaParsedFileUrls.Has(baseUrl.String, out index)
             )
             {
+                // 循環参照・過深チェイン検知: 優先度更新経路でも無限ループしない
+                if (toLoadUrls.Has(baseUrl.String) || toLoadUrls.Length >= MAX_BASE_CHAIN_HOPS)
+                {
+                    ConsoleError($"Circular or too-deep base URL chain detected: {baseUrl.String}", _eiaFileLoaderPrefixes);
+                    break;
+                }
+                if (!EiaParsedFileUrls.Has(baseUrl.String, out index)) break;
                 toLoadUrls = toLoadUrls.Append(baseUrl.String);
             }
 
@@ -234,6 +248,17 @@ namespace jp.ootr.ImageDeviceController
                 ? (int)uncompressedToken.Double
                 : uncompressedToken.Int;
 
+            // LZ4 展開爆弾対策: 悪意のある uncompressedSize で大量アロケーションを誘発されないように上限
+            if (uncompressedSize <= 0 || uncompressedSize > MAX_UNCOMPRESSED_BYTES)
+            {
+                ConsoleError(
+                    $"Uncompressed size out of range: {_eiaCurrentFileUrl} ({uncompressedSize} bytes)",
+                    _eiaFileLoaderPrefixes);
+                OnFileLoadError(_eiaCurrentFileUrl, LoadError.SizeLimitExceeded);
+                SendCustomEvent(nameof(EIALoadFIleNext));
+                return;
+            }
+
             ConsoleDebug(
                 $"Decompressing {_eiaCurrentFileUrl} compressed size: {EiaParsedFileBuffers[_eiaCurrentFileIndex].Length} uncompressed size: {uncompressedSize}",
                 _eiaFileLoaderPrefixes);
@@ -316,6 +341,15 @@ namespace jp.ootr.ImageDeviceController
             _eiaCurrentFileBaseUrl = baseUrl.String;
             _eiaCurrentFileBytesPerPixel = TextureFormat.RGB24.GetBytePerPixel();
 
+            // 多重防御: パース時に検証済みだが、アロケーション直前でも寸法上限を再確認
+            if (!TryValidateImageDimensions(_eiaCurrentFileWidth, _eiaCurrentFileHeight, _eiaCurrentFileBytesPerPixel, out var dimErr))
+            {
+                ConsoleError(
+                    $"EIA cropped dimensions exceed limits: {_eiaCurrentFileUrl} ({_eiaCurrentFileWidth}x{_eiaCurrentFileHeight}) - {dimErr}",
+                    _eiaFileLoaderPrefixes);
+                EIAOnGenerateImageBytesError(dimErr);
+                return;
+            }
 
             ConsoleDebug($"EIAGenerateImageBytesAsyncInit: {Time.realtimeSinceStartup - _eiaProcessStartTime}",
                 _eiaFileLoaderPrefixes);
@@ -339,6 +373,16 @@ namespace jp.ootr.ImageDeviceController
             _eiaCurrentFileHeight = (int)height.Double;
             _eiaCurrentFileBytesPerPixel = TextureFormat.RGB24.GetBytePerPixel();
 
+            // 多重防御: master 画像の寸法上限を再確認
+            if (!TryValidateImageDimensions(_eiaCurrentFileWidth, _eiaCurrentFileHeight, _eiaCurrentFileBytesPerPixel, out var dimErr))
+            {
+                ConsoleError(
+                    $"EIA master dimensions exceed limits: {_eiaCurrentFileUrl} ({_eiaCurrentFileWidth}x{_eiaCurrentFileHeight}) - {dimErr}",
+                    _eiaFileLoaderPrefixes);
+                EIAOnGenerateImageBytesError(dimErr);
+                return;
+            }
+
             ConsoleDebug(
                 $"EIAGenerateImageBytesAsyncInit,EIAGenerateImageBytesAsyncMaster: {Time.realtimeSinceStartup - _eiaProcessStartTime}",
                 _eiaFileLoaderPrefixes);
@@ -358,6 +402,15 @@ namespace jp.ootr.ImageDeviceController
 
             _eiaCurrentFileBinary =
                 new byte[_eiaCurrentFileWidth * _eiaCurrentFileHeight * _eiaCurrentFileBytesPerPixel];
+            if (sourceBinary.Length != _eiaCurrentFileBinary.Length)
+            {
+                // 派生ファイルと base 画像の寸法が噛み合わない = マニフェスト不正
+                ConsoleError(
+                    $"base/child size mismatch: src={sourceBinary.Length} dst={_eiaCurrentFileBinary.Length}",
+                    _eiaFileLoaderPrefixes);
+                EIAOnGenerateImageBytesError(LoadError.MalformedManifest);
+                return;
+            }
             Array.Copy(sourceBinary, _eiaCurrentFileBinary, sourceBinary.Length);
 
             ConsoleDebug($"EIAGenerateImageBytesAsyncInitCopy: {Time.realtimeSinceStartup - _eiaProcessStartTime}",
@@ -405,8 +458,42 @@ namespace jp.ootr.ImageDeviceController
                 : rectHeightToken.Int;
             var start = startToken.TokenType == TokenType.Double ? (int)startToken.Double : startToken.Int;
 
+            // rect 境界検証: 負値・巨大値・オーバーフローによる ArgumentOutOfRangeException や
+            // base 画像への範囲外書き込み・整数オーバーフロー OOB を防ぐ
+            if (
+                baseX < 0 || baseY < 0 || rectWidth <= 0 || rectHeight <= 0 || start < 0
+                || (long)baseX + rectWidth > _eiaCurrentFileWidth
+                || (long)baseY + rectHeight > _eiaCurrentFileHeight
+            )
+            {
+                ConsoleError(
+                    $"Rect out of range: baseX={baseX} baseY={baseY} w={rectWidth} h={rectHeight} start={start}",
+                    _eiaFileLoaderPrefixes);
+                EIAOnGenerateImageBytesError(LoadError.MalformedManifest);
+                return;
+            }
+
             var rectLineByteLength = rectWidth * _eiaCurrentFileBytesPerPixel;
             var imageLineByteLength = _eiaCurrentFileWidth * _eiaCurrentFileBytesPerPixel;
+
+            // 最終行の src/dst オフセットが配列境界内に収まるかを long で確認
+            var lastSrcOffset = (long)start + (long)(rectHeight - 1) * rectLineByteLength;
+            var lastDstOffset = (long)(baseY + rectHeight - 1) * imageLineByteLength
+                              + (long)baseX * _eiaCurrentFileBytesPerPixel;
+            if (
+                _eiaCurrentDecodedData == null
+                || lastSrcOffset + rectLineByteLength > _eiaCurrentDecodedData.Length
+                || _eiaCurrentFileBinary == null
+                || lastDstOffset + rectLineByteLength > _eiaCurrentFileBinary.Length
+            )
+            {
+                ConsoleError(
+                    $"Rect copy would overrun buffer: src={lastSrcOffset + rectLineByteLength} dst={lastDstOffset + rectLineByteLength}",
+                    _eiaFileLoaderPrefixes);
+                EIAOnGenerateImageBytesError(LoadError.MalformedManifest);
+                return;
+            }
+
             for (var y = 0; y < rectHeight; y++)
             {
                 Array.Copy(
@@ -433,8 +520,13 @@ namespace jp.ootr.ImageDeviceController
 
         private void EIAOnGenerateImageBytesError()
         {
+            EIAOnGenerateImageBytesError(LoadError.InvalidFileURL);
+        }
+
+        private void EIAOnGenerateImageBytesError(LoadError error)
+        {
             ConsoleDebug($"Failed to decode file: {_eiaCurrentFileUrl}", _eiaFileLoaderPrefixes);
-            OnFileLoadError(_eiaCurrentFileUrl, LoadError.InvalidFileURL);
+            OnFileLoadError(_eiaCurrentFileUrl, error);
 
             EIAClear();
             SendCustomEventDelayedSeconds(nameof(EIALoadFIleNext), 1f);
@@ -443,6 +535,19 @@ namespace jp.ootr.ImageDeviceController
         private void EIAOnGenerateImageBytesSuccess()
         {
             _eiaProcessStartTime = Time.realtimeSinceStartup;
+
+            // LoadRawTextureData は w*h*bpp と data.Length が一致しない場合に UnityException を投げる
+            // 悪意のある manifest で長さ不一致 → Udon スクリプト停止となるのを防ぐ
+            var expected = (long)_eiaCurrentFileWidth * _eiaCurrentFileHeight * _eiaCurrentFileFormat.GetBytePerPixel();
+            if (_eiaCurrentFileBinary == null || _eiaCurrentFileBinary.Length != expected)
+            {
+                ConsoleError(
+                    $"Raw texture size mismatch: expected={expected} actual={(_eiaCurrentFileBinary == null ? -1 : _eiaCurrentFileBinary.Length)}",
+                    _eiaFileLoaderPrefixes);
+                EIAOnGenerateImageBytesError(LoadError.MalformedManifest);
+                return;
+            }
+
             var texture = new Texture2D(_eiaCurrentFileWidth, _eiaCurrentFileHeight, _eiaCurrentFileFormat, false);
             texture.LoadRawTextureData(_eiaCurrentFileBinary);
             texture.Apply();


### PR DESCRIPTION
EIA マニフェスト / TextZip metadata 直読み値が検証されずに new byte[] /
new Texture2D / Array.Copy / udonLZ4.DecompressAsync に流れていたため、
攻撃者が配布する EIA / TextZip を踏ませるだけでクライアントをクラッシュ /
フリーズ / メモリ枯渇させられる経路を塞ぐ。

- LoadError に MalformedManifest / CircularReference / SizeLimitExceeded を追加
- CommonClass に MAX_IMAGE_DIMENSION=4096 / MAX_UNCOMPRESSED_BYTES=64MiB /
  MAX_BASE_CHAIN_HOPS=16 定数と TryValidateImageDimensions ヘルパーを追加
- EIASourceLoader: マニフェスト解析時点で w*h*bpp(最悪4) の上限検証
- EIAFileLoader: base URL チェインの循環参照 / 過深チェインを検出 (2 箇所),
  uncompressedSize の上限チェック, rect 座標・サイズ・コピー先境界の検証,
  base/派生 バッファ長の一致確認, LoadRawTextureData 前の長さ不一致検出,
  EIAOnGenerateImageBytesError に LoadError を受け取る overload を追加
- ZipSourceLoader: metadata 時点で寸法を検証, rect 座標・サイズ・
  コピー先境界を検証